### PR TITLE
Implement dragging of theme customization UI

### DIFF
--- a/R/theme-preview.R
+++ b/R/theme-preview.R
@@ -114,10 +114,13 @@ bs_themer_ui <- function() {
       "bs_themer", version = packageVersion("bootstraplib"), src = "themer", script = "themer.js", package = "bootstraplib", all_files = FALSE
     ),
 
-    div(class = "card shadow", style = css(width = "18rem", max_height = "80vh", z_index = 1000),
+    div(id = "bsthemerContainer",
+      class = "card shadow", style = css(width = "18rem", max_height = "80vh", z_index = 1000),
       style = css(position = "fixed", top = "1rem", right = "1rem", height = "auto"),
 
-      div(class = "card-header font-weight-bold bg-dark text-light px-3 py-2",
+      div(id = "bsthemerHeader",
+        class = "move-grabber", "data-target" = "#bsthemerContainer",
+        class = "card-header font-weight-bold bg-dark text-light px-3 py-2",
         "Theme customizer",
         tags$div(id = "bsthemerToggle", class = "float-right",
           "data-toggle" = "collapse", "data-target" = "#bsthemerAccordion",

--- a/inst/themer/themer.js
+++ b/inst/themer/themer.js
@@ -272,7 +272,7 @@
     active_move_offset = {
       x: e.clientX - active_move_target.offsetLeft,
       y: e.clientY - active_move_target.offsetTop
-    }
+    };
 
     if (active_move_grabber.setPointerCapture) {
       active_move_grabber.setPointerCapture(e.pointerId);
@@ -296,16 +296,12 @@
       return;
     }
 
-    var move_target = active_move_target;
-
     if (active_move_grabber.setPointerCapture) {
       active_move_grabber.releasePointerCapture(e.pointerId);
     }
     active_move_grabber = null;
     active_move_target = null;
     active_move_offset = null;
-
-    constrain(move_target);
   });
 
   /**
@@ -341,20 +337,16 @@
     };
 
     if (elBounds.top <= elBounds.bottom) {
-      console.log("top")
       el.style.top = Math.max(0, elBounds.top) + "px";
       el.style.bottom = "auto";
     } else {
-      console.log("bottom")
       el.style.top = "auto";
       el.style.bottom = Math.max(0, elBounds.bottom) + "px";
     }
     if (elBounds.left <= elBounds.right) {
-      console.log("left")
       el.style.left = Math.max(0, elBounds.left) + "px";
       el.style.right = "auto";
     } else {
-      console.log("right")
       el.style.left = "auto";
       el.style.right = Math.max(0, elBounds.right) + "px";
     }

--- a/inst/themer/themer.scss
+++ b/inst/themer/themer.scss
@@ -11,4 +11,6 @@
 
 .move-grabber {
   cursor: move;
+  /* Required to avoid scrolling on mobile safari */
+  touch-action: none;
 }

--- a/inst/themer/themer.scss
+++ b/inst/themer/themer.scss
@@ -8,3 +8,7 @@
 #bsthemerToggle.collapsed span {
   @include caret(down);
 }
+
+.move-grabber {
+  cursor: move;
+}


### PR DESCRIPTION
A few non-obvious edge case behaviors to note:

1. When the window is resized, the theme customization UI should stay the same distance from its closest corner
2. The theme customization UI cannot be moved beyond the edge of the browser window
3. The collapse animation moves toward the nearest edge (but the caret always points down to expand, up to collapse; you could argue for it changing to point to the nearest edge, though I suspect it would be more confusing to see the arrow direction change simply from dragging past the middle of the screen)
4. On browsers that support it (unfortunately not RStudio desktop, at least on Linux) dragging operations should continue even if the cursor moves outside the browser