### PR TITLE
Have themer try it's best to disable the initial bootstrap stylesheet

### DIFF
--- a/R/theme-preview.R
+++ b/R/theme-preview.R
@@ -111,7 +111,9 @@ bs_themer_ui <- function() {
   withTags(tagList(
     colorpicker_deps(),
     htmlDependency(
-      "bs_themer", version = packageVersion("bootstraplib"), src = "themer", script = "themer.js", package = "bootstraplib", all_files = FALSE
+      "bs_themer", version = packageVersion("bootstraplib"),
+      src = "themer", script = c("disable-bootstrap.js", "themer.js"),
+      package = "bootstraplib", all_files = FALSE
     ),
 
     div(id = "bsthemerContainer",
@@ -316,7 +318,6 @@ bs_themer <- function() {
 
     message("---")
 
-
     # Change variables names to their 'high-level' equivalents
     # Note that if _either_ fg/bg has changed, bs_theme_base_colors()
     # needs to be called with *both* fg and bg populated.
@@ -338,6 +339,13 @@ bs_themer <- function() {
       error = function(e) { warning(e$message); NULL }
     )
     if (!is.null(css)) {
+      # Find and disable the main bootstrap-custom.css that will likely
+      # be defined in the UI. Disabling this 'initial' stylesheet is needed
+      # for things like $enable-rounded to work properly because the initial
+      # stylesheet may still want to impose rules that would disappear entirely
+      # without it
+      session$sendCustomMessage("bootstraplib-themer-disable-bootstrap", list(disable = TRUE))
+      # Now, insert the newly compiled Bootstrap CSS
       shiny::insertUI(
         "head", where = "beforeEnd",
         ui = tags$style(
@@ -347,7 +355,6 @@ bs_themer <- function() {
       )
       shiny::removeUI("#bs-realtime-preview-styles:not(:last-child)")
     }
-
   })
 }
 

--- a/inst/themer/disable-bootstrap.js
+++ b/inst/themer/disable-bootstrap.js
@@ -1,0 +1,13 @@
+// Try our best to find and disable bootstrap CSS.
+// This is needed, because although
+Shiny.addCustomMessageHandler("bootstraplib-themer-disable-bootstrap", function(msg) {
+  var sheets = document.styleSheets;
+  for (i = 0; i < sheets.length; i++) {
+    var href = sheets[i].href || "";
+    var href_parts = href.split("/");
+    var basename = href_parts[href_parts.length - 1];
+    if (basename.match(/^bootstrap(-custom)?(.min)?.css$/)) {
+      sheets[i].disabled = true;
+    }
+  }
+});


### PR DESCRIPTION
## reprex of issue

```r
library(bootstraplib)
bs_theme_preview()
```

Disable the "rounded corners" option. Notice how the well and pills still have rounded corners. The reason is that with `$enable-rounded: false`, `border-radius` isn't defined; however, since the initial Bootstrap CSS is built with `$enable-rounded: true`, the rules from the initial build still apply