### PR TITLE
If fg/bg hasn't changed, themer should fallback to vals named black/whit

### DIFF
--- a/R/theme-preview.R
+++ b/R/theme-preview.R
@@ -323,8 +323,8 @@ bs_themer <- function() {
     # needs to be called with *both* fg and bg populated.
     changed_vals <- rename(changed_vals, c(bg = "white", fg = "black", base = "font-family-base", code = "font-family-monospace", heading = "headings-font-family"))
     if (any(c("fg", "bg") %in% names(changed_vals))) {
-      changed_vals[["fg"]] <- changed_vals[["fg"]] %||% vals[["fg"]]
-      changed_vals[["bg"]] <- changed_vals[["bg"]] %||% vals[["bg"]]
+      changed_vals[["fg"]] <- changed_vals[["fg"]] %||% vals[["black"]]
+      changed_vals[["bg"]] <- changed_vals[["bg"]] %||% vals[["white"]]
     }
     changed_vals <- take_and_use_values(changed_vals, bs_theme_base_colors)
     changed_vals <- take_and_use_values(changed_vals, bs_theme_accent_colors)


### PR DESCRIPTION
## reprex

```r
library(bootstraplib)
bs_theme_new()
bs_theme_base_colors(bg = "#444", fg = "#e4e4e4")
bs_theme_preview()
```

Change the background color to a darker color. Note how the text doesn't contrast appropriately

