### PR TITLE
Don't force write_attachments = F in bootstrap_sass()

### DIFF
--- a/R/bs_sass.R
+++ b/R/bs_sass.R
@@ -105,7 +105,7 @@ bootstrap <- function(theme = bs_theme_get(),
 bootstrap_sass <- function(rules = list(), theme = bs_theme_get(), ...) {
   theme <- as_bs_theme(theme)
   theme$rules <- ""
-  sass::sass(input = list(theme, rules), write_attachments = FALSE, ...)
+  sass::sass(input = list(theme, rules), ...)
 }
 
 


### PR DESCRIPTION
It seems safer to throw warnings and allow users to decide what they want to do (someday we may want to `write_attachments=T` when compiling CSS for Shiny inputs, for instance)