### PR TITLE
Use consistent output directory for bootstrap()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,4 @@ Collate:
 Remotes:
     rstudio/thematic,
     rstudio/jquerylib,
-    rstudio/sass@disk-cache
+    rstudio/sass

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,9 +46,9 @@ Collate:
     'layers.R'
     'theme-add.R'
     'theme-custom.R'
+    'utils.R'
     'theme-preview.R'
     'themes.R'
-    'utils.R'
     'versions.R'
 Remotes: 
     rstudio/thematic,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     grDevices,
     htmltools (>= 0.4.0.9003),
     jsonlite,
-    sass (>= 0.2.0),
+    sass (>= 0.2.0.9001),
     jquerylib (>= 0.1.2),
     rlang
 Suggests:
@@ -35,7 +35,7 @@ Suggests:
 License: MIT | file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Collate: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,5 +52,5 @@ Collate:
     'versions.R'
 Remotes:
     rstudio/thematic,
-    rstudio/jquerylib
+    rstudio/jquerylib,
     rstudio/sass@disk-cache

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
     )
 Description: Tools for obtaining bootstrap CSS and customizing it via SASS.
 Depends: R (>= 2.10)
-Imports: 
+Imports:
     grDevices,
     htmltools (>= 0.4.0.9003),
     jsonlite,
@@ -38,7 +38,7 @@ LazyData: true
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
-Collate: 
+Collate:
     'bootswatch.R'
     'bs_sass.R'
     'files.R'
@@ -50,6 +50,7 @@ Collate:
     'theme-preview.R'
     'themes.R'
     'versions.R'
-Remotes: 
+Remotes:
     rstudio/thematic,
     rstudio/jquerylib
+    rstudio/sass@disk-cache

--- a/R/bs_sass.R
+++ b/R/bs_sass.R
@@ -61,7 +61,16 @@ bootstrap <- function(theme = bs_theme_get(),
   )
   opts <- utils::modifyList(opts, options)
 
-  cache_key <- sass::sass_cache_key(theme, opts)
+  output_css <- if (minified) "bootstrap-custom.min.css" else "bootstrap-custom.css"
+  version <- theme_version(theme)
+  js <- bootstrap_javascript(version, minified)
+
+  cache_key <- sass::sass_hash(list(
+      theme,
+      opts,
+      get_exact_version(version),
+      utils::packageVersion("bootstraplib")
+  ))
 
   # Temp dir for building the HTML dependencies
   output_path <- file.path(
@@ -69,10 +78,6 @@ bootstrap <- function(theme = bs_theme_get(),
     "bootstraplib",
     paste0("bootstrap-", cache_key)
   )
-
-  output_css <- if (minified) "bootstrap-custom.min.css" else "bootstrap-custom.css"
-  version <- theme_version(theme)
-  js <- bootstrap_javascript(version, minified)
 
   # If the output path already exists, then
   if (!dir.exists(output_path)) {
@@ -95,7 +100,7 @@ bootstrap <- function(theme = bs_theme_get(),
     list(
       htmlDependency(
         "bootstrap",
-        if (version %in% "3") version_bs3 else version_bs4,
+        get_exact_version(version),
         src = output_path,
         meta = c(
           name = "viewport",

--- a/R/bs_sass.R
+++ b/R/bs_sass.R
@@ -52,7 +52,7 @@
 #'
 bootstrap <- function(theme = bs_theme_get(),
                       sass_options = sass::sass_options(output_style = "compressed"),
-                      cache_options = sass::sass_cache_options(),
+                      cache = sass::sass_cache_get(),
                       jquery = jquerylib::jquery_core(3)) {
 
   theme <- as_bs_theme(theme)
@@ -84,7 +84,7 @@ bootstrap <- function(theme = bs_theme_get(),
       input = theme,
       options = sass_options,
       output = file.path(output_path, output_css),
-      cache_options = cache_options,
+      cache = cache,
       write_attachments = TRUE
     )
 

--- a/R/layers.R
+++ b/R/layers.R
@@ -87,9 +87,9 @@ bootstrap_javascript <- function(version, minified = TRUE) {
 
 bs3compat_layer <- function() {
   sass_layer(
-    defaults = sass_file(system.file("bs3compat", "_defaults.scss", package = "bootstraplib")),
-    declarations = sass_file(system.file("bs3compat", "_declarations.scss", package = "bootstraplib")),
-    rules = sass_file(system.file("bs3compat", "_rules.scss", package = "bootstraplib")),
+    defaults = sass_file(system_file("bs3compat", "_defaults.scss", package = "bootstraplib")),
+    declarations = sass_file(system_file("bs3compat", "_declarations.scss", package = "bootstraplib")),
+    rules = sass_file(system_file("bs3compat", "_rules.scss", package = "bootstraplib")),
     # Gyliphicon font files
     file_attachments = c(
       fonts = lib_file("bootstrap-sass/assets/fonts")
@@ -117,7 +117,7 @@ bootswatch_layer <- function(bootswatch, version) {
   attachments <- if (file.exists(font_css)) {
     c(
       "font.css" = font_css,
-      fonts = system.file("fonts", package = "bootstraplib")
+      fonts = system_file("fonts", package = "bootstraplib")
     )
   }
 

--- a/R/theme-preview.R
+++ b/R/theme-preview.R
@@ -46,12 +46,16 @@ colorpicker_deps <- function() {
   )
 }
 
-opts_metadata <- jsonlite::fromJSON(system_file("themer/options.json", package = "bootstraplib"),
-  simplifyDataFrame = FALSE)
+opts_metadata <- function() {
+  jsonlite::fromJSON(
+    system_file("themer/options.json", package = "bootstraplib"),
+    simplifyDataFrame = FALSE
+  )
+}
 
 bs_themer_ui <- function() {
 
-  computed_defaults <- bs_theme_get_variables(unlist(unname(lapply(opts_metadata, names))))
+  computed_defaults <- bs_theme_get_variables(unlist(unname(lapply(opts_metadata(), names))))
 
   make_control <- function(id, lbl, default_value, type, desc = NULL) {
     default_value <- computed_defaults[[id]]
@@ -106,7 +110,7 @@ bs_themer_ui <- function() {
     }
   }
 
-  opts <- lapply(opts_metadata, function(opt_infos) {
+  opts <- lapply(opts_metadata(), function(opt_infos) {
     mapply(names(opt_infos), opt_infos, FUN = function(name, opt_info) {
       make_control(name, opt_info$label, opt_info$default, opt_info$type, opt_info$desc)
     }, USE.NAMES = FALSE, SIMPLIFY = FALSE)

--- a/R/theme-preview.R
+++ b/R/theme-preview.R
@@ -1,3 +1,6 @@
+#' @include utils.R
+NULL
+
 #' Preview the currently set theme
 #'
 #' Launches an example shiny app via `run_with_themer()` and `bootstrap()`.
@@ -24,7 +27,7 @@ bs_theme_preview <- function(..., with_themer = TRUE, auto_theme = rlang::is_ins
     shiny::onStop(thematic::thematic_off)
   }
   # TODO: add more this demo and also an option for launching different demos
-  app <- system.file("themer-demo", package = "bootstraplib")
+  app <- system_file("themer-demo", package = "bootstraplib")
   if (with_themer) {
     run_with_themer(app, ...)
   } else {
@@ -43,7 +46,7 @@ colorpicker_deps <- function() {
   )
 }
 
-opts_metadata <- jsonlite::fromJSON(system.file("themer/options.json", package = "bootstraplib"),
+opts_metadata <- jsonlite::fromJSON(system_file("themer/options.json", package = "bootstraplib"),
   simplifyDataFrame = FALSE)
 
 bs_themer_ui <- function() {
@@ -129,7 +132,7 @@ bs_themer_ui <- function() {
           "data-toggle" = "collapse", "data-target" = "#bsthemerAccordion",
           style = css(cursor = "pointer"),
           tags$span(),
-          tags$style(HTML(bootstrap_sass(sass::sass_file(system.file("themer/themer.scss", package = "bootstraplib")))))
+          tags$style(HTML(bootstrap_sass(sass::sass_file(system_file("themer/themer.scss", package = "bootstraplib")))))
         )
       ),
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -75,6 +75,10 @@ system_file <- local({
   package_dir_cache <- character()
 
   function(..., package = "base") {
+    if (!is.null(names(list(...)))) {
+      stop("All arguments other than `package` must be unnamed.")
+    }
+
     if (package %in% names(package_dir_cache)) {
       package_dir <- package_dir_cache[[package]]
     } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,6 +7,10 @@ version_resolve <- function(version) {
   match.arg(version, c("4+3", "4", "3"))
 }
 
+get_exact_version <- function(version) {
+  if (version %in% "3") version_bs3 else version_bs4
+}
+
 lib_file <- function(...) {
   file <- system_file("lib", ..., package = "bootstraplib")
   if (file != "") return(file)

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,7 +8,7 @@ version_resolve <- function(version) {
 }
 
 lib_file <- function(...) {
-  file <- system.file("lib", ..., package = "bootstraplib")
+  file <- system_file("lib", ..., package = "bootstraplib")
   if (file != "") return(file)
   stop(
     "bootstraplib file not found: '", file.path(...), "'",
@@ -63,3 +63,21 @@ color_yiq <- function(r, g, b) {
 color_yiq_islight <- function(r, g, b, threshold = 150) {
   color_yiq(r, g, b) >= threshold
 }
+
+
+# Wrapper around base::system.file. In base::system.file, the package directory
+# lookup is a bit slow. This caches the package directory, so it is much faster.
+system_file <- local({
+  package_dir_cache <- character()
+
+  function(..., package = "base") {
+    if (package %in% names(package_dir_cache)) {
+      package_dir <- package_dir_cache[[package]]
+    } else {
+      package_dir <- system.file(package = package)
+      package_dir_cache[[package]] <<- package_dir
+    }
+
+    file.path(package_dir, ...)
+  }
+})

--- a/man/bootstrap.Rd
+++ b/man/bootstrap.Rd
@@ -8,7 +8,7 @@
 bootstrap(
   theme = bs_theme_get(),
   sass_options = sass::sass_options(output_style = "compressed"),
-  cache_options = sass::sass_cache_options(),
+  cache = sass::sass_cache_get(),
   jquery = jquerylib::jquery_core(3)
 )
 
@@ -31,9 +31,8 @@ custom layers to the current theme without affecting the global state (e.g.,
 
 \item{sass_options}{see \code{\link[sass:sass_options]{sass::sass_options()}}.}
 
-\item{cache_options}{Caching options for Sass. Please specify options using
-\code{\link[sass]{sass_cache_options}}. Caching is turned off by default for
-interactive R sessions, and turned on for non-interactive ones.}
+\item{cache}{A \link[sass]{FileCache} object created by \code{\link[sass:sass_file_cache]{sass_file_cache()}}, or \code{NULL}
+for no caching.}
 
 \item{jquery}{See \code{\link[jquerylib:jquery_core]{jquerylib::jquery_core()}}.}
 


### PR DESCRIPTION
This PR does the following:

* When the inputs are the same, it uses the same output directory every time. If the output directory already exists, it won't bother writing files there.
* Adds a wrapper function `system_file()`, which is faster than `system.file`. (The latter was a bottleneck.)

Before the `system_file` change:
```
> system.time(bootstrap())
   user  system elapsed 
  0.403   0.038   0.441 
> system.time(bootstrap())
   user  system elapsed 
  0.034   0.009   0.043
```

After:

```
> system.time(bootstrap())
   user  system elapsed 
  0.385   0.032   0.416 
> system.time(bootstrap())
   user  system elapsed 
  0.010   0.003   0.013 
```

This should be merged after https://github.com/rstudio/sass/pull/44. (The `Remotes` field here will have to be updated after that PR is merged.)


*****

Testing notes:

Run the following. Each time you run `dir(outdir)`, the output should be the same -- there should be exactly one directory listed with a name like `"bootstrap-xxxxxxx"`. If there is more than one such directory, then there's a problem.

```R
library(bootstraplib)
outdir <- file.path(tempdir(), "bootstraplib")

bootstrap()
dir(outdir)
#> [1] "bootstrap-560e344a81bc5cbe"

bootstrap()
dir(outdir)
#> [1] "bootstrap-560e344a81bc5cbe"
```
