### PR TITLE
Fix bootstrap()'s meta viewport tag

### DIFF
--- a/R/bs_sass.R
+++ b/R/bs_sass.R
@@ -85,10 +85,7 @@ bootstrap <- function(theme = bs_theme_get(),
         src = dirname(out_file),
         stylesheet = basename(out_file),
         script = basename(js),
-        meta = c(
-          name = "viewport",
-          content = "width=device-width, initial-scale=1, shrink-to-fit=no"
-        )
+        meta = list(viewport = "width=device-width, initial-scale=1, shrink-to-fit=no")
       )
     ),
     theme$html_deps

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ To start using **bootstraplib** in your **shiny** apps today, install `remotes::
 shiny::shinyOptions(bootstraplib = TRUE)
 ```
 
-2. Call `bs_theme_new()` and optionally specify a Bootstrap `version` and [`bootswatch` theme](https://bootswatch.com/). The current default is Bootstrap 4 (with added added Bootstrap 3 compatibility) and no `bootswatch` theme:
+2. Call `bs_theme_new()` and optionally specify a Bootstrap `version` and [`bootswatch` theme](https://bootswatch.com/). The current default is Bootstrap 4 (with added Bootstrap 3 compatibility) and no `bootswatch` theme:
 
 ```r
 bs_theme_new(version = "4+3", bootswatch = NULL)


### PR DESCRIPTION
Closes #83.

The issue here is that we want to include

```html
<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
```

with Bootstrap, but we're currently generating:

```r
dep <- htmlDependency(
  "foo", "1.0", src = c(href = "/"), 
  meta = c(	        
    name = "viewport",	
    content = "width=device-width, initial-scale=1, shrink-to-fit=no"	
  )
)
renderDependencies(list(dep), "href")
```

```html
<meta name="name" content="viewport" />
<meta name="content" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
```

This fixes that problem