### PR TITLE
'Intelligent' management of global state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Collate:
+    'globals.R'
     'bootswatch.R'
     'bs_sass.R'
     'files.R'

--- a/R/globals.R
+++ b/R/globals.R
@@ -1,0 +1,1 @@
+.globals <- new.env(parent = emptyenv())

--- a/R/themes.R
+++ b/R/themes.R
@@ -85,10 +85,8 @@ bs_theme_clear <- function() {
 #' @param theme a theme object (i.e., the return value of `bs_theme_get()`).
 #' @export
 bs_theme_set <- function(theme) {
-  if (!is.null(theme)) {
-    theme <- as_bs_theme(theme)
-  }
-  old_theme <- options(bootstraplib_theme = theme)
+
+  old_theme <- bs_theme_set_(theme)
 
   if (shiny::isRunning()) {
 
@@ -97,7 +95,7 @@ bs_theme_set <- function(theme) {
     if (is.null(.globals$themePriorToShinyRun)) {
       .globals$themePriorToShinyRun <- old_theme
       shiny::onStop(function() {
-        bs_theme_set(.globals$themePriorToShinyRun)
+        bs_theme_set_(.globals$themePriorToShinyRun)
         .globals$themePriorToShinyRun <- NULL
       })
     }
@@ -106,11 +104,18 @@ bs_theme_set <- function(theme) {
 
     # If this code is running outside of a running shiny app, then clear the theme when
     # the next app exits. This helps to avoid the problem of sourcing bootstraplib/shiny
-    # code for a particular example, but then having all downstream code
+    # code for a particular example and having future code impacted by it
     shiny::onStop(bs_theme_clear)
   }
 
+  invisible(old_theme)
+}
 
+bs_theme_set_ <- function(theme) {
+  if (!is.null(theme)) {
+    theme <- as_bs_theme(theme)
+  }
+  old_theme <- options(bootstraplib_theme = theme)
   invisible(old_theme[["bootstraplib_theme"]])
 }
 

--- a/R/themes.R
+++ b/R/themes.R
@@ -88,7 +88,7 @@ bs_theme_set <- function(theme) {
 
   old_theme <- bs_theme_set_(theme)
 
-  if (shiny::isRunning()) {
+  if (is_shiny_app()) {
 
     # If this is the 1st time we're setting a theme inside a runApp() (or similar), then
     # after the app exits, restore the theme to whatever it was prior to running the app

--- a/R/themes.R
+++ b/R/themes.R
@@ -105,7 +105,14 @@ bs_theme_set <- function(theme) {
     # If this code is running outside of a running shiny app, then clear the theme when
     # the next app exits. This helps to avoid the problem of sourcing bootstraplib/shiny
     # code for a particular example and having future code impacted by it
-    shiny::onStop(bs_theme_clear)
+    if ("shiny" %in% loadedNamespaces()) {
+      shiny::onStop(bs_theme_clear)
+    } else {
+      set_hook_once(
+        packageEvent("shiny", "onLoad"),
+        function() shiny::onStop(bs_theme_clear)
+      )
+    }
   }
 
   invisible(old_theme)
@@ -118,7 +125,6 @@ bs_theme_set_ <- function(theme) {
   old_theme <- options(bootstraplib_theme = theme)
   invisible(old_theme[["bootstraplib_theme"]])
 }
-
 
 bs_theme_create <- function(version = version_default()) {
   version <- version_resolve(version)

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,3 +94,11 @@ system_file <- local({
 is_shiny_app <- function() {
   "shiny" %in% loadedNamespaces() && shiny::isRunning()
 }
+
+# Like setHook(), but ensures that value (i.e., the hook) is only ever set once
+set_hook_once <- function(hookName, value) {
+  hook_is_value <- vapply(getHook(hookName), identical, logical(1), value)
+  if (!any(hook_is_value)) {
+    setHook(hookName, value)
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,3 +89,8 @@ system_file <- local({
     file.path(package_dir, ...)
   }
 })
+
+
+is_shiny_app <- function() {
+  "shiny" %in% loadedNamespaces() && shiny::isRunning()
+}


### PR DESCRIPTION
(To be merged after https://github.com/rstudio/shiny/pull/3062)

This PR makes it so that running a shiny app via file (i.e., `runApp()`) won't alter bootstraplib's global state. That is, the following should always be `TRUE`:

```r
theme <- bs_theme_get()
shiny::runApp()
identical(theme, bs_theme_get())
#> TRUE
```

On the other hand, if the app's source is copy/pasted into the R console, then the bootstraplib theme will always be cleared after the app exits:

```r
bs_theme_new()
shinyApp(fluidPage(), function(input, output) {})
bs_theme_get()
#> NULL
``` 
